### PR TITLE
Fix HUD tab layout and drag cursor

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -1,20 +1,21 @@
 {
   "tokenActionHud": {
-    "template": {
-      "armor": "Armor",
-      "containers": "Containers",
-      "consumables": "Consumables",
-      "equipment": "Equipment",
-      "inventory": "Inventory",
-      "item": "Item",
-      "weapons": "Weapons",
-      "treasure": "Treasure",
-      "settings": {
-        "displayUnequipped": {
-          "hint": "Choose whether to display unequipped items on the HUD",
-          "name": "Display Unequipped"
-        }
-      }
+    "crookedfalls": {
+      "actions": "Actions",
+      "tagsTab": "Tags",
+      "pool": "Roll",
+      "fogDefense": "Fog Defense",
+      "tag": "Tag",
+      "power": "Power",
+      "interference": "Interference",
+      "pools": "Pools",
+      "tags": "Tags",
+      "items": "Items",
+      "powers": "Powers",
+      "intellect": "Intellect",
+      "agility": "Agility",
+      "willpower": "Willpower",
+      "contestedPriority": "Contested Priority"
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -16,8 +16,8 @@
   "flags": {},
   "version": "This is auto replaced",
   "compatibility": {
-    "minimum": "11",
-    "verified": "11.313"
+    "minimum": "12",
+    "verified": "13.345"
   },
   "esmodules": [
     "./scripts/init.js"
@@ -54,9 +54,8 @@
         "type": "module",
         "compatibility": [
           {
-            "minimum": "1.5.0",
-            "maximum": "1.5",
-            "verified": "1.5.0"
+            "minimum": "2.0.0",
+            "verified": "2.0.16"
           }
         ]
       }

--- a/module.json
+++ b/module.json
@@ -1,8 +1,12 @@
 {
-  "id": "token-action-hud-template",
-  "title": "Token Action HUD Template",
-  "description": "Token Action HUD is a repositionable HUD of actions for a selected token",
+  "id": "token-action-hud-crookedfalls",
+  "title": "Token Action HUD - Crooked Falls",
+  "description": "Token Action HUD is a repositionable HUD of actions for a selected token. This companion module adds support for the Crooked Falls system.",
   "authors": [
+    {
+      "name": "themrbeasley",
+      "discord": "gamemasterbeas"
+    },
     {
       "name": "Larkinabout",
       "url": "https://github.com/Larkinabout"
@@ -21,7 +25,7 @@
   "scripts": [
   ],
   "styles": [
-    "./styles/tah-template-style.css"
+    "./styles/tah-crookedfalls-style.css"
   ],
   "languages": [
     {
@@ -34,12 +38,12 @@
   "relationships": {
     "systems": [
       {
-        "id": "template",
+        "id": "crookedfalls",
         "type": "system",
         "compatibility": [
           {
             "minimum": "1.0.0",
-            "verified": "1.0.0"
+            "verified": "1.1.0"
           }
         ]
       }
@@ -65,7 +69,7 @@
   "socket": false,
   "manifest": "This is auto replaced",
   "download": "This is auto replaced",
-  "readme": "https://github.com/Larkinabout/fvtt-token-action-hud-template#readme",
+  "readme": "https://github.com/themrbeasley/fvtt-token-action-hud-crookedfalls#readme",
   "protected": false,
   "coreTranslation": false,
   "library": false

--- a/readme.md
+++ b/readme.md
@@ -1,48 +1,61 @@
-![Downloads](https://img.shields.io/github/downloads/Larkinabout/fvtt-token-action-hud-template/latest/module.zip?color=2b82fc&label=DOWNLOADS&style=for-the-badge) [![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Ftoken-action-hud-template&colorB=448d34&style=for-the-badge)](https://forge-vtt.com/bazaar#package=token-action-hud-template)
+# Token Action HUD - Crooked Falls
 
-# Token Action HUD Template
-
-Token Action HUD is a repositionable HUD of actions for a selected token.
-
-![Token Action HUD](.github/readme/token-action-hud.gif)
+Token Action HUD is a repositionable HUD of actions for a selected token. This companion module adds support for the **Crooked Falls** game system.
 
 # Features
-- Make rolls directly from the HUD instead of opening your character sheet.
-- Use items from the HUD or right-click an item to open its sheet.
-- Move the HUD and choose to expand the menus up or down.
+
+- Roll **Intellect**, **Agility**, or **Willpower** pools directly from the HUD — opens the full roll dialog with tag bonuses and Resolve spending.
+- Trigger **Fog Defense** from the HUD to roll willpower defense or spend Fog Resistance.
+- Browse an investigator's **Tags** and **Items** directly from the HUD. Left-click posts an item to chat; right-click opens its sheet.
+- GMs can activate or end a Threat's **Powers** and trigger **Interference** effects from the HUD.
+- **Contested Priority** button (GM only) launches the priority roll dialog from the HUD.
+- **End Turn** in combat when it's the selected token's turn.
+- Move the HUD and choose to expand menus up or down.
 - Unlock the HUD to customise layout and groups per user, and actions per actor.
 - Add your own macros, journal entries and roll table compendiums.
+
+# HUD Layout
+
+| Tab | Groups | Actor Type |
+|-----|--------|------------|
+| Actions | Pools (Intellect / Agility / Willpower), Fog Defense | Investigator |
+| Actions | Powers, Interference | Threat |
+| Tags | Tags (narrative), Items (limited-use) | Investigator |
+| Utility | Combat (End Turn, Contested Priority) | All |
 
 # Installation
 
 ## Method 1
 1. On Foundry VTT's **Configuration and Setup** screen, go to **Add-on Modules**
 2. Click **Install Module**
-3. Search for **Token Action HUD Pathfinder 2** 
+3. Search for **Token Action HUD Crooked Falls**
 4. Click **Install** next to the module listing
 
 ## Method 2
 1. On Foundry VTT's **Configuration and Setup** screen, go to **Add-on Modules**
 2. Click **Install Module**
-3. In the Manifest URL field, paste: `https://github.com/Larkinabout/fvtt-token-action-hud-template/releases/latest/download/module.json`
+3. In the Manifest URL field, paste the manifest URL for this module
 4. Click **Install** next to the pasted Manifest URL
 
 ## Required Modules
 
-**IMPORTANT** - Token Action HUD Template requires the [Token Action HUD Core](https://foundryvtt.com/packages/token-action-hud-core) module to be installed.
+**IMPORTANT** - This module requires both:
+- The [Crooked Falls](https://github.com/themrbeasley/crookedfalls) game system
+- The [Token Action HUD Core](https://foundryvtt.com/packages/token-action-hud-core) module (minimum version 1.5.0)
 
 ## Recommended Modules
 Token Action HUD uses the [Color Picker](https://foundryvtt.com/packages/color-picker) library module for its color picker settings.
 
 # Support
 
+For questions, feature requests or bug reports, please open an issue on the GitHub repository.
+
 For a guide on using Token Action HUD, go to: [How to Use Token Action HUD](https://github.com/Larkinabout/fvtt-token-action-hud-core/wiki/How-to-Use-Token-Action-HUD)
 
-For questions, feature requests or bug reports, please open an issue [here](https://github.com/Larkinabout/fvtt-token-action-hud-core/issues).
-
-Pull requests are welcome. Please include a reason for the request or create an issue before starting one.
-
 # Acknowledgements
+
+- **themrbeasley** — Module author and Crooked Falls system designer
+- **Larkinabout** — Creator of Token Action HUD Core and the companion module template
 
 Thank you to the Community Helpers on Foundry's Discord who provide tireless support for people seeking help with the HUD.
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,11 +9,11 @@ export default [
                 'scripts/*/*.js'
             ],
             exclude: [
-                'scripts/token-action-hud-template.min.js']
+                'scripts/token-action-hud-crookedfalls.min.js']
         },
         output: {
             format: 'esm',
-            file: 'scripts/token-action-hud-template.min.js'
+            file: 'scripts/token-action-hud-crookedfalls.min.js'
         },
         plugins: [
             terser({ keep_classnames: true, keep_fnames: true }),

--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -1,6 +1,5 @@
 // System Module Imports
-import { ACTION_TYPE, ITEM_TYPE } from './constants.js'
-import { Utils } from './utils.js'
+import { ACTION_TYPE } from './constants.js'
 
 export let ActionHandler = null
 
@@ -14,92 +13,239 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          * Called by Token Action HUD Core
          * @override
          * @param {array} groupIds
-         */a
+         */
         async buildSystemActions (groupIds) {
-            // Set actor and token variables
             this.actors = (!this.actor) ? this._getActors() : [this.actor]
             this.actorType = this.actor?.type
 
-            // Settings
-            this.displayUnequipped = Utils.getSetting('displayUnequipped')
-
-            // Set items variable
-            if (this.actor) {
-                let items = this.actor.items
-                items = coreModule.api.Utils.sortItemsByName(items)
-                this.items = items
-            }
-
-            if (this.actorType === 'character') {
-                this.#buildCharacterActions()
+            if (this.actorType === 'investigator') {
+                await this.#buildInvestigatorActions()
+            } else if (this.actorType === 'threat') {
+                await this.#buildThreatActions()
             } else if (!this.actor) {
                 this.#buildMultipleTokenActions()
             }
+            // npc: no mechanical actions
         }
 
         /**
-         * Build character actions
+         * Build investigator actions (pool rolls, fog defense, tags)
          * @private
          */
-        #buildCharacterActions () {
-            this.#buildInventory()
+        async #buildInvestigatorActions () {
+            this.#buildPools()
+            this.#buildFogDefense()
+            this.#buildTags()
+            this.#buildCombat()
+        }
+
+        /**
+         * Build threat actions (powers and interference)
+         * @private
+         */
+        async #buildThreatActions () {
+            this.#buildPowers()
+            this.#buildInterference()
+            this.#buildCombat()
         }
 
         /**
          * Build multiple token actions
          * @private
-         * @returns {object}
          */
         #buildMultipleTokenActions () {
         }
 
         /**
-         * Build inventory
+         * Build pool roll actions (Intellect, Agility, Willpower)
          * @private
          */
-        async #buildInventory () {
-            if (this.items.size === 0) return
+        #buildPools () {
+            const actionTypeId = 'pool'
+            const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
+            const groupData = { id: 'pools', type: 'system' }
 
-            const actionTypeId = 'item'
-            const inventoryMap = new Map()
+            const pools = [
+                { id: 'intellect', name: coreModule.api.Utils.i18n('tokenActionHud.crookedfalls.intellect') },
+                { id: 'agility',   name: coreModule.api.Utils.i18n('tokenActionHud.crookedfalls.agility') },
+                { id: 'willpower', name: coreModule.api.Utils.i18n('tokenActionHud.crookedfalls.willpower') }
+            ]
 
-            for (const [itemId, itemData] of this.items) {
-                const type = itemData.type
-                const equipped = itemData.equipped
+            const actions = pools.map(pool => ({
+                id: pool.id,
+                name: pool.name,
+                listName: `${actionTypeName ? `${actionTypeName}: ` : ''}${pool.name}`,
+                encodedValue: [actionTypeId, pool.id].join(this.delimiter)
+            }))
 
-                if (equipped || this.displayUnequipped) {
-                    const typeMap = inventoryMap.get(type) ?? new Map()
-                    typeMap.set(itemId, itemData)
-                    inventoryMap.set(type, typeMap)
-                }
-            }
+            this.addActions(actions, groupData)
+        }
 
-            for (const [type, typeMap] of inventoryMap) {
-                const groupId = ITEM_TYPE[type]?.groupId
+        /**
+         * Build fog defense action
+         * @private
+         */
+        #buildFogDefense () {
+            const actionTypeId = 'fogDefense'
+            const name = coreModule.api.Utils.i18n('tokenActionHud.crookedfalls.fogDefense')
+            const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
+            const groupData = { id: 'fogDefense', type: 'system' }
 
-                if (!groupId) continue
+            const actions = [{
+                id: 'fogDefense',
+                name,
+                listName: `${actionTypeName ? `${actionTypeName}: ` : ''}${name}`,
+                encodedValue: [actionTypeId, 'fogDefense'].join(this.delimiter)
+            }]
 
-                const groupData = { id: groupId, type: 'system' }
+            this.addActions(actions, groupData)
+        }
 
-                // Get actions
-                const actions = [...typeMap].map(([itemId, itemData]) => {
-                    const id = itemId
-                    const name = itemData.name
-                    const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
-                    const listName = `${actionTypeName ? `${actionTypeName}: ` : ''}${name}`
-                    const encodedValue = [actionTypeId, id].join(this.delimiter)
+        /**
+         * Build tag actions (narrative tags and item tags)
+         * @private
+         */
+        #buildTags () {
+            if (!this.actor) return
 
-                    return {
-                        id,
-                        name,
-                        listName,
-                        encodedValue
-                    }
-                })
+            const eligibleTags = this.actor.items.filter(i => {
+                if (i.type !== 'tag') return false
+                if (i.system.kind === 'wound') return false
+                if (i.name === 'Incapacitated') return false
+                if (i.system.kind === 'item' && i.system.uses_enabled && i.system.uses_value <= 0) return false
+                return true
+            })
 
-                // TAH Core method to add actions to the action list
+            const actionTypeId = 'tag'
+            const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
+
+            // Narrative tags → 'tags' group
+            const narrativeTags = eligibleTags
+                .filter(i => i.system.kind === 'tag')
+                .sort((a, b) => a.name.localeCompare(b.name))
+
+            if (narrativeTags.length > 0) {
+                const groupData = { id: 'tags', type: 'system' }
+                const actions = narrativeTags.map(item => ({
+                    id: item.id,
+                    name: item.name,
+                    listName: `${actionTypeName ? `${actionTypeName}: ` : ''}${item.name}`,
+                    encodedValue: [actionTypeId, item.id].join(this.delimiter)
+                }))
                 this.addActions(actions, groupData)
             }
+
+            // Item tags → 'items' group (show use count when tracked)
+            const itemTags = eligibleTags
+                .filter(i => i.system.kind === 'item')
+                .sort((a, b) => a.name.localeCompare(b.name))
+
+            if (itemTags.length > 0) {
+                const groupData = { id: 'items', type: 'system' }
+                const actions = itemTags.map(item => {
+                    const useSuffix = item.system.uses_enabled
+                        ? ` (${item.system.uses_value}/${item.system.uses_max})`
+                        : ''
+                    const name = `${item.name}${useSuffix}`
+                    return {
+                        id: item.id,
+                        name,
+                        listName: `${actionTypeName ? `${actionTypeName}: ` : ''}${name}`,
+                        encodedValue: [actionTypeId, item.id].join(this.delimiter)
+                    }
+                })
+                this.addActions(actions, groupData)
+            }
+        }
+
+        /**
+         * Build power actions for threats
+         * @private
+         */
+        #buildPowers () {
+            if (!this.actor) return
+
+            const powers = this.actor.items
+                .filter(i => i.type === 'power')
+                .sort((a, b) => a.name.localeCompare(b.name))
+
+            if (powers.length === 0) return
+
+            const actionTypeId = 'power'
+            const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
+            const groupData = { id: 'powers', type: 'system' }
+
+            const actions = powers.map(item => {
+                const isActive = item.system.active ?? false
+                const name = isActive ? `[Active] ${item.name}` : item.name
+                return {
+                    id: item.id,
+                    name,
+                    listName: `${actionTypeName ? `${actionTypeName}: ` : ''}${item.name}`,
+                    encodedValue: [actionTypeId, item.id].join(this.delimiter)
+                }
+            })
+
+            this.addActions(actions, groupData)
+        }
+
+        /**
+         * Build interference actions for threats
+         * @private
+         */
+        #buildInterference () {
+            if (!this.actor) return
+
+            const interferences = this.actor.items
+                .filter(i => i.type === 'interference')
+                .sort((a, b) => a.name.localeCompare(b.name))
+
+            if (interferences.length === 0) return
+
+            const actionTypeId = 'interference'
+            const actionTypeName = coreModule.api.Utils.i18n(ACTION_TYPE[actionTypeId])
+            const groupData = { id: 'interference', type: 'system' }
+
+            const actions = interferences.map(item => ({
+                id: item.id,
+                name: item.name,
+                listName: `${actionTypeName ? `${actionTypeName}: ` : ''}${item.name}`,
+                encodedValue: [actionTypeId, item.id].join(this.delimiter)
+            }))
+
+            this.addActions(actions, groupData)
+        }
+
+        /**
+         * Build combat utility actions (End Turn, Contested Priority)
+         * @private
+         */
+        #buildCombat () {
+            const actionTypeId = 'utility'
+            const groupData = { id: 'combat', type: 'system' }
+            const actions = []
+
+            if (game.combat) {
+                const name = coreModule.api.Utils.i18n('tokenActionHud.endTurn')
+                actions.push({
+                    id: 'endTurn',
+                    name,
+                    listName: name,
+                    encodedValue: [actionTypeId, 'endTurn'].join(this.delimiter)
+                })
+            }
+
+            if (game.user.isGM && this.actorType === 'investigator') {
+                const name = coreModule.api.Utils.i18n('tokenActionHud.crookedfalls.contestedPriority')
+                actions.push({
+                    id: 'contestedPriority',
+                    name,
+                    listName: name,
+                    encodedValue: [actionTypeId, 'contestedPriority'].join(this.delimiter)
+                })
+            }
+
+            if (actions.length > 0) this.addActions(actions, groupData)
         }
     }
 })

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -15,7 +15,7 @@ export const CORE_MODULE = {
 /**
  * Core module version required by the system module
  */
-export const REQUIRED_CORE_MODULE_VERSION = '1.5'
+export const REQUIRED_CORE_MODULE_VERSION = '2.0'
 
 /**
  * Action types

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -2,7 +2,7 @@
  * Module-based constants
  */
 export const MODULE = {
-    ID: 'token-action-hud-template'
+    ID: 'token-action-hud-crookedfalls'
 }
 
 /**
@@ -21,33 +21,25 @@ export const REQUIRED_CORE_MODULE_VERSION = '1.5'
  * Action types
  */
 export const ACTION_TYPE = {
-    item: 'tokenActionHud.template.item',
-    utility: 'tokenActionHud.utility'
+    pool:         'tokenActionHud.crookedfalls.pool',
+    fogDefense:   'tokenActionHud.crookedfalls.fogDefense',
+    tag:          'tokenActionHud.crookedfalls.tag',
+    power:        'tokenActionHud.crookedfalls.power',
+    interference: 'tokenActionHud.crookedfalls.interference',
+    utility:      'tokenActionHud.utility'
 }
 
 /**
  * Groups
  */
 export const GROUP = {
-    armor: { id: 'armor', name: 'tokenActionHud.template.armor', type: 'system' },
-    equipment: { id: 'equipment', name: 'tokenActionHud.template.equipment', type: 'system' },
-    consumables: { id: 'consumables', name: 'tokenActionHud.template.consumables', type: 'system' },
-    containers: { id: 'containers', name: 'tokenActionHud.template.containers', type: 'system' },
-    treasure: { id: 'treasure', name: 'tokenActionHud.template.treasure', type: 'system' },
-    weapons: { id: 'weapons', name: 'tokenActionHud.template.weapons', type: 'system' },
-    combat: { id: 'combat', name: 'tokenActionHud.combat', type: 'system' },
-    token: { id: 'token', name: 'tokenActionHud.token', type: 'system' },
-    utility: { id: 'utility', name: 'tokenActionHud.utility', type: 'system' }
-}
-
-/**
- * Item types
- */
-export const ITEM_TYPE = {
-    armor: { groupId: 'armor' },
-    backpack: { groupId: 'containers' },
-    consumable: { groupId: 'consumables' },
-    equipment: { groupId: 'equipment' },
-    treasure: { groupId: 'treasure' },
-    weapon: { groupId: 'weapons' }
+    pools:        { id: 'pools',        name: 'tokenActionHud.crookedfalls.pools',        type: 'system' },
+    fogDefense:   { id: 'fogDefense',   name: 'tokenActionHud.crookedfalls.fogDefense',   type: 'system' },
+    tags:         { id: 'tags',         name: 'tokenActionHud.crookedfalls.tags',          type: 'system' },
+    items:        { id: 'items',        name: 'tokenActionHud.crookedfalls.items',         type: 'system' },
+    powers:       { id: 'powers',       name: 'tokenActionHud.crookedfalls.powers',        type: 'system' },
+    interference: { id: 'interference', name: 'tokenActionHud.crookedfalls.interference',  type: 'system' },
+    combat:       { id: 'combat',       name: 'tokenActionHud.combat',                     type: 'system' },
+    token:        { id: 'token',        name: 'tokenActionHud.token',                      type: 'system' },
+    utility:      { id: 'utility',      name: 'tokenActionHud.utility',                    type: 'system' }
 }

--- a/scripts/defaults.js
+++ b/scripts/defaults.js
@@ -15,16 +15,23 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
     DEFAULTS = {
         layout: [
             {
-                nestId: 'inventory',
-                id: 'inventory',
-                name: coreModule.api.Utils.i18n('Template.Inventory'),
+                nestId: 'actions',
+                id: 'actions',
+                name: coreModule.api.Utils.i18n('tokenActionHud.crookedfalls.actions'),
                 groups: [
-                    { ...groups.weapons, nestId: 'inventory_weapons' },
-                    { ...groups.armor, nestId: 'inventory_armor' },
-                    { ...groups.equipment, nestId: 'inventory_equipment' },
-                    { ...groups.consumables, nestId: 'inventory_consumables' },
-                    { ...groups.containers, nestId: 'inventory_containers' },
-                    { ...groups.treasure, nestId: 'inventory_treasure' }
+                    { ...groups.pools,        nestId: 'actions_pools' },
+                    { ...groups.fogDefense,   nestId: 'actions_fogDefense' },
+                    { ...groups.powers,       nestId: 'actions_powers' },
+                    { ...groups.interference, nestId: 'actions_interference' }
+                ]
+            },
+            {
+                nestId: 'tags',
+                id: 'tags',
+                name: coreModule.api.Utils.i18n('tokenActionHud.crookedfalls.tagsTab'),
+                groups: [
+                    { ...groups.tags,  nestId: 'tags_tags' },
+                    { ...groups.items, nestId: 'tags_items' }
                 ]
             },
             {
@@ -32,9 +39,8 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 id: 'utility',
                 name: coreModule.api.Utils.i18n('tokenActionHud.utility'),
                 groups: [
-                    { ...groups.combat, nestId: 'utility_combat' },
-                    { ...groups.token, nestId: 'utility_token' },
-                    { ...groups.rests, nestId: 'utility_rests' },
+                    { ...groups.combat,  nestId: 'utility_combat' },
+                    { ...groups.token,   nestId: 'utility_token' },
                     { ...groups.utility, nestId: 'utility_utility' }
                 ]
             }

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -15,13 +15,14 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
         async handleActionClick (event, encodedValue) {
             const [actionTypeId, actionId] = encodedValue.split('|')
 
-            const renderable = ['item']
+            // Right-clicking a tag opens its item sheet
+            const renderable = ['tag']
 
             if (renderable.includes(actionTypeId) && this.isRenderItem()) {
                 return this.doRenderItem(this.actor, actionId)
             }
 
-            const knownCharacters = ['character']
+            const knownCharacters = ['investigator', 'threat']
 
             // If single actor is selected
             if (this.actor) {
@@ -68,39 +69,100 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         async #handleAction (event, actor, token, actionTypeId, actionId) {
             switch (actionTypeId) {
-            case 'item':
-                this.#handleItemAction(event, actor, actionId)
+            case 'pool':
+                await this.#handlePoolAction(actor, actionId)
+                break
+            case 'fogDefense':
+                await this.#handleFogDefenseAction(actor)
+                break
+            case 'tag':
+                await this.#handleTagAction(event, actor, actionId)
+                break
+            case 'power':
+                await this.#handlePowerAction(actor, actionId)
+                break
+            case 'interference':
+                await this.#handleInterferenceAction(actor, actionId)
                 break
             case 'utility':
-                this.#handleUtilityAction(token, actionId)
+                await this.#handleUtilityAction(token, actor, actionId)
                 break
             }
         }
 
         /**
-         * Handle item action
+         * Handle pool roll action (intellect, agility, willpower)
+         * Delegates to the investigator sheet's roll dialog
+         * @private
+         * @param {object} actor   The actor
+         * @param {string} poolName The pool to roll (intellect | agility | willpower)
+         */
+        async #handlePoolAction (actor, poolName) {
+            await actor.sheet._rollPool(poolName)
+        }
+
+        /**
+         * Handle fog defense action
+         * Delegates to the investigator sheet's fog defense dialog
+         * @private
+         * @param {object} actor The actor
+         */
+        async #handleFogDefenseAction (actor) {
+            await actor.sheet._rollFogDefense()
+        }
+
+        /**
+         * Handle tag action (left-click posts to chat)
          * @private
          * @param {object} event    The event
          * @param {object} actor    The actor
-         * @param {string} actionId The action id
+         * @param {string} actionId The item id
          */
-        #handleItemAction (event, actor, actionId) {
+        async #handleTagAction (event, actor, actionId) {
             const item = actor.items.get(actionId)
-            item.toChat(event)
+            if (item) item.toChat(event)
+        }
+
+        /**
+         * Handle power action
+         * Delegates to the threat sheet's power activation/deactivation
+         * @private
+         * @param {object} actor    The actor
+         * @param {string} actionId The item id
+         */
+        async #handlePowerAction (actor, actionId) {
+            const item = actor.items.get(actionId)
+            if (item) await actor.sheet._usePower(item)
+        }
+
+        /**
+         * Handle interference action
+         * Delegates to the threat sheet's interference flow
+         * @private
+         * @param {object} actor    The actor
+         * @param {string} actionId The item id
+         */
+        async #handleInterferenceAction (actor, actionId) {
+            const item = actor.items.get(actionId)
+            if (item) await actor.sheet._useInterference(item)
         }
 
         /**
          * Handle utility action
          * @private
          * @param {object} token    The token
+         * @param {object} actor    The actor
          * @param {string} actionId The action id
          */
-        async #handleUtilityAction (token, actionId) {
+        async #handleUtilityAction (token, actor, actionId) {
             switch (actionId) {
             case 'endTurn':
                 if (game.combat?.current?.tokenId === token.id) {
                     await game.combat?.nextTurn()
                 }
+                break
+            case 'contestedPriority':
+                await game.crookedfalls.ContestedPriority.begin()
                 break
             }
         }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,21 +1,8 @@
-import { MODULE } from './constants.js'
-
 /**
  * Register module settings
  * Called by Token Action HUD Core to register Token Action HUD system module settings
  * @param {function} coreUpdate Token Action HUD Core update function
  */
 export function register (coreUpdate) {
-    game.settings.register(MODULE.ID, 'displayUnequipped', {
-        name: game.i18n.localize('tokenActionHud.template.settings.displayUnequipped.name'),
-        hint: game.i18n.localize('tokenActionHud.template.settings.displayUnequipped.hint'
-        ),
-        scope: 'client',
-        config: true,
-        type: Boolean,
-        default: true,
-        onChange: (value) => {
-            coreUpdate(value)
-        }
-    })
+    // No system-specific settings at this time
 }

--- a/scripts/system-manager.js
+++ b/scripts/system-manager.js
@@ -30,7 +30,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          * @returns {object} The available roll handlers
          */
         getAvailableRollHandlers () {
-            const coreTitle = 'Core Template'
+            const coreTitle = 'Core Crooked Falls'
             const choices = { core: coreTitle }
             return choices
         }
@@ -80,11 +80,11 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         registerStyles () {
             return {
-                template: {
-                    class: 'tah-style-template-style', // The class to add to first DIV element
-                    file: 'tah-template-style', // The file without the css extension
+                crookedfalls: {
+                    class: 'tah-style-crookedfalls-style', // The class to add to first DIV element
+                    file: 'tah-crookedfalls-style', // The file without the css extension
                     moduleId: MODULE.ID, // The module ID
-                    name: 'Template Style' // The name to display in the Token Action HUD Core 'Style' module setting
+                    name: 'Crooked Falls Style' // The name to display in the Token Action HUD Core 'Style' module setting
                 }
             }
         }

--- a/styles/tah-crookedfalls-style.css
+++ b/styles/tah-crookedfalls-style.css
@@ -1,0 +1,484 @@
+:root {
+    --tah-background-color: #00000000;
+    --tah-border-radius: 3px;
+    --tah-gap: 5px;
+
+    --tah-button-background-color: #000000b3;
+    --tah-button-border-color: none;
+    --tah-button-box-shadow: 0 2px 0 -1px #0c0c0c, 0 0 0 1px #060606,
+        0 0 5px #000000ff;
+    --tah-button-disabled-text-color: var(--tah-text-secondary-color);
+    --tah-button-text-color: var(--tah-text-primary-color);
+    --tah-button-height: 32px;
+    --tah-button-min-width: 32px;
+    --tah-button-hover-box-shadow: 0 2px 0 -1px var(--tah-text-tertiary-color),
+        0 0 0 1px red, 0 0 10px var(--tah-text-tertiary-color);
+    --tah-button-hover-text-color: #fff;
+    --tah-button-active-background-color: #3c0078bf;
+    --tah-button-active-box-shadow: 0 0 0 1px #9b8dff, inset 0 0 10px #9b8dff;
+    --tah-button-toggle-background-color: #000000b3;
+    --tah-button-toggle-hover-background-color: #3c0078bf;
+    --tah-button-toggle-hover-box-shadow: 0 0 0 1px #9b8dff, 0 0 10px #9b8dff;
+    --tah-text-disabled-color: var(--tah-text-secondary-color);
+    --tah-text-primary-color: #dddddd;
+    --tah-text-secondary-color: #dddddd80;
+    --tah-text-tertiary-color: #ff6400;
+    --tah-text-hover-primary-color: var(--tah-text-primary-color);
+    --tah-text-hover-secondary-color: var(--tah-text-secondary-color);
+    --tah-text-hover-tertiary-color: var(--tah-text-tertiary-color);
+    --tah-text-shadow: 1px 1px 1px rgb(0 0 0), 0px 1px 3px rgb(0 0 0);
+}
+
+#token-action-hud {
+    align-items: center;
+    border-radius: var(--tah-border-radius);
+    display: flex;
+    flex-direction: row;
+    height: auto;
+    left: 150px;
+    position: fixed;
+    top: 80px;
+    width: auto;
+    z-index: 100;
+}
+
+#token-action-hud [class*="icon-"] {
+    display: inline-block;
+    width: 100%;
+}
+
+#tah-character-name {
+    color: var(--tah-text-primary-color);
+    font-size: var(--font-size-16);
+    margin: 0;
+    padding: 0;
+    pointer-events: none;
+    position: absolute;
+    text-align: left;
+    text-shadow: var(--tah-text-shadow);
+    top: -22px !important;
+}
+
+.tah-hidden {
+    display: none !important;
+}
+
+#token-action-hud:hover #tah-collapse-hud,
+#token-action-hud:hover > #tah-buttons {
+    display: flex;
+}
+
+#tah-collapse-hud,
+#tah-buttons {
+    align-items: center;
+    display: none;
+    font-style: normal;
+    font-weight: normal;
+    height: var(--tah-button-height);
+    position: relative;
+    z-index: 1;
+}
+
+#tah-collapse-expand {
+    font-style: normal;
+    font-weight: normal;
+    left: -16px;
+    position: absolute;
+}
+
+#tah-collapse-hud,
+#tah-buttons button {
+    background: transparent;
+    border: 0;
+    line-height: unset;
+    margin: 0;
+    padding: 0;
+}
+
+#tah-collapse-hud:hover,
+#tah-collapse-hud:focus,
+#tah-buttons button:hover,
+#tah-buttons button:focus {
+    box-shadow: none;
+}
+
+#tah-collapse-expand button > :is(.fa, .fas),
+#tah-buttons button > :is(.fa, .fas) {
+    color: var(--tah-text-primary-color);
+    font-size: var(--font-size-12);
+    margin: 3px;
+    padding: 3px;
+    pointer-events: none;
+    position: relative;
+    text-align: center;
+    text-shadow: var(--tah-text-shadow);
+}
+
+#tah-collapse-expand button > :is(.fa, .fas) {
+    font-size: medium;
+}
+
+#tah-collapse-hud {
+    left: -3px;
+}
+
+#tah-expand-hud {
+    left: -3px;
+    top: 16px;
+}
+
+#tah-expand-hud,
+#tah-expand-hud:focus,
+.tah-action-button,
+.tah-action-button:focus,
+.tah-group-button,
+.tah-group-button:focus {
+    align-items: center;
+    background-color: var(--tah-button-background-color);
+    border: var(--tah-button-border-color);
+    border-radius: var(--tah-border-radius);
+    box-shadow: var(--tah-button-box-shadow);
+    color: var(--tah-button-text-color);
+    display: flex;
+    height: var(--tah-button-height);
+    margin: 0;
+    padding: 0;
+    position: relative;
+    text-align: center;
+    text-decoration: none;
+    text-shadow: var(--tah-text-shadow);
+    transition: all 0.1s ease-in-out;
+    white-space: nowrap;
+    z-index: 1;
+}
+
+.tah-action-button,
+.tah-group-button {
+    font-size: var(--font-size-13);
+    min-width: var(--tah-button-min-width);
+}
+
+#tah-expand-hud:hover,
+.tah-action-button:active,
+.tah-action-button:not(.disabled):hover,
+.tah-group-button:not(.disabled):hover {
+    box-shadow: var(--tah-button-hover-box-shadow);
+    color: var(--tah-button-hover-text-color);
+}
+
+.tah-action-button.toggle:not(.disabled):hover {
+    background: var(--tah-button-toggle-hover-background-color);
+    box-shadow: var(--tah-button-toggle-hover-box-shadow);
+}
+
+.tah-action-button.active {
+    background: var(--tah-button-active-background-color);
+    box-shadow: var(--tah-button-active-box-shadow);
+}
+
+.tah-action-button.active.activeText > .tah-action-button-content:after {
+    content: "*";
+}
+
+.tah-action-button.disabled {
+    color: var(--tah-button-disabled-text-color);
+}
+
+.tah-action-button.disabled:hover {
+    box-shadow: var(--tah-button-box-shadow);
+}
+
+.tah-action-button.shrink {
+    min-width: min-content;
+}
+
+.tah-group-button > :is(.fa, .fas) {
+    font-size: 8px;
+    position: absolute;
+    right: 0px;
+    top: 2px;
+    visibility: hidden;
+}
+
+.tah-group-button:hover:not(.disable-edit)
+    > :is(.fa, .fas) {
+    visibility: visible;
+}
+
+.tah-button-content:empty {
+    display: none;
+}
+
+.tah-button-content {
+    align-items: center;
+    display: flex;
+    gap: var(--tah-gap);
+    overflow: hidden;
+    padding: 0 10px;
+    width: 100%;
+}
+
+.tah-button-text {
+    padding: 0;
+}
+
+.tah-action-button-content {
+    align-items: center;
+    display: flex;
+    gap: var(--tah-gap);
+    overflow: hidden;
+    padding: 0 10px;
+    width: 100%;
+}
+
+.tah-action-button-text {
+    overflow: hidden;
+    padding-right: 1px;
+    text-align: left;
+    text-overflow: ellipsis;
+    width: 100%;
+}
+
+#tah-collapse-expand:hover button > i,
+#tah-buttons button:hover > i {
+    color: var(--tah-text-hover-primary-color);
+    text-shadow: 0 0 8px var(--color-shadow-primary);
+}
+
+#tah-edit-hud > :is(.fa, .fas) {
+    font-size: var(--font-size-16);
+}
+
+#tah-groups,
+.tah-tab-groups {
+    display: flex;
+    gap: var(--tah-gap);
+    position: relative;
+}
+
+.tah-tab-groups {
+    width: max-content;
+}
+
+.tah-tab-group,
+.tah-group {
+    display: flex;
+    position: relative;
+}
+
+.tah-groups-container {
+    display: none;
+    position: absolute;
+}
+
+.tah-tab-group.hover > .tah-groups-container,
+.tah-tab-group.hover > .tah-groups-container > .tah-groups {
+    display: flex;
+}
+
+.tah-tab-group > .tah-groups-container.expand-down > .tah-groups {
+    flex-direction: column;
+    left: -10px;
+    padding: 3px 10px 10px 10px;
+    position: relative;
+}
+
+.tah-tab-group > .tah-groups-container.expand-up > .tah-groups {
+    flex-direction: column;
+    left: -10px;
+    padding: 10px 10px 3px 10px;
+    position: relative;
+}
+
+#tah-groups > .tah-tab-group > .tah-groups-container.expand-up > .tah-groups {
+    flex-direction: column-reverse;
+}
+
+.tah-tab-group > .tah-groups-container.expand-down {
+    top: calc(100% - 7px);
+    padding-top: 10px;
+}
+
+.tah-tab-group > .tah-groups-container.expand-up {
+    bottom: calc(100% + 3px + -10px);
+    flex-direction: column-reverse;
+    padding-bottom: 10px;
+}
+
+.tah-tab-group
+    > .tah-groups-container.expand-up
+    > .tah-groups
+    > .tah-list-groups {
+    flex-direction: column-reverse;
+}
+
+.tah-list-groups,
+.tah-tab-groups > .tah-tab-group > .tah-groups > .tah-actions {
+    background: var(--tah-background-color);
+    border-radius: var(--tah-border-radius);
+}
+
+.tah-list-groups {
+    flex-direction: column;
+    display: flex;
+    gap: var(--tah-gap);
+}
+
+.tah-list-groups .tah-list-groups {
+    background: none;
+}
+
+.tah-list-group {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.tah-groups {
+    display: flex;
+    flex-direction: column;
+    gap: var(--tah-gap);
+    width: max-content;
+}
+
+.tah-groups.expand-down {
+    flex-direction: column;
+}
+
+#tah-groups.tah-unlocked
+    .tah-group
+    > .tah-groups
+    > .tah-list-groups
+    > .tah-group {
+    padding-left: 10px;
+}
+
+.tah-group[data-show-title="false"]
+    > .tah-list-group
+    > .tah-groups
+    > .tah-list-groups
+    > .tah-group:not([data-show-title="false"]) {
+    padding-left: 0px;
+}
+
+.tah-group:not([data-show-title="false"])[data-has-image="false"]
+    > .tah-list-group
+    > .tah-groups
+    > .tah-list-groups
+    > .tah-group:not([data-show-title="false"])[data-has-image="false"] {
+    padding-left: 10px;
+}
+
+.tah-unlocked
+    .tah-group
+    > .tah-list-group
+    > .tah-groups
+    > .tah-list-groups
+    > .tah-group {
+    padding-left: 10px;
+}
+
+.tah-subtitle {
+    align-items: center;
+    color: var(--tah-text-primary-color);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: var(--tah-font-size-10);
+    gap: var(--tah-gap);
+    letter-spacing: 0.1em;
+    line-height: 1;
+    text-shadow: var(--tah-text-shadow);
+    text-transform: uppercase;
+}
+
+.tah-subtitle:hover {
+    color: var(--tah-text-hover-primary-color);
+    cursor: pointer;
+}
+
+.tah-subtitle-text {
+    color: var(--tah-text-primary-color);
+}
+
+.tah-group[data-show-title="false"] > div > .tah-subtitle > .tah-subtitle-text {
+    color: var(--tah-text-disabled-color);
+}
+
+.tah-subtitle > :is(.tah-edit-icon, .tah-collapse-icon, .tah-expand-icon) {
+    bottom: 1px;
+    font-size: 8px;
+    pointer-events: none;
+    position: relative;
+    visibility: hidden;
+}
+
+.tah-subtitle:hover
+    > :is(
+        .tah-collapse-icon:not(.tah-hidden),
+        .tah-expand-icon:not(.tah-hidden)
+    ),
+.tah-subtitle:hover:not(.disable-edit) > .tah-edit-icon {
+    visibility: visible;
+}
+
+.tah-tab-group > .tah-actions {
+    margin-top: 5px;
+}
+
+.tah-actions {
+    align-items: center;
+    display: flex;
+    flex-flow: row wrap;
+    gap: var(--tah-gap);
+    width: 100%;
+}
+
+.tah-info1,
+.tah-info2,
+.tah-info3 {
+    color: var(--tah-text-secondary-color);
+    font-size: xx-small;
+}
+
+.tah-info1.tah-spotlight,
+.tah-info2.tah-spotlight,
+.tah-info3.tah-spotlight {
+    color: var(--tah-text-tertiary-color);
+}
+
+.tah-subtitle > :is(.tah-info1, .tah-info2, .tah-info3) {
+    background: var(--tah-button-background-color);
+    border-radius: 5px;
+    margin: 1px;
+    padding: 1px 3px;
+}
+
+.tah-button-image {
+    border-radius: var(--tah-border-radius);
+    height: var(--tah-button-height);
+    min-width: var(--tah-button-min-width);
+    width: var(--tah-button-min-width);
+}
+
+.tah-list-image {
+    border: none;
+    border-radius: var(--tah-border-radius);
+    box-shadow: var(--tah-button-box-shadow);
+    height: var(--tah-button-height);
+    margin-right: 5px;
+    min-width: var(--tah-button-min-width);
+    width: var(--tah-button-min-width);
+}
+
+.tah-icon > :is(.fa, .fas) {
+    font-size: x-small;
+    margin: 0px 2px 0px 0px;
+}
+
+.tah-icon-disabled {
+    color: var(--tah-text-disabled-color);
+}
+
+.tah-subtitle > .tah-icon > :is(.fa, .fas) {
+    text-shadow: var(--tah-text-shadow);
+}

--- a/styles/tah-crookedfalls-style.css
+++ b/styles/tah-crookedfalls-style.css
@@ -32,6 +32,7 @@
 #token-action-hud {
     align-items: center;
     border-radius: var(--tah-border-radius);
+    cursor: grab;
     display: flex;
     flex-direction: row;
     height: auto;
@@ -252,6 +253,7 @@
 #tah-groups,
 .tah-tab-groups {
     display: flex;
+    flex-direction: row;
     gap: var(--tah-gap);
     position: relative;
 }


### PR DESCRIPTION
## Summary

- Forces tab buttons (Actions / Tags / Utility) to render in a horizontal row by setting `flex-direction: row` on `#tah-groups` and `.tah-tab-groups`, overriding TAH Core 2.0's default column layout
- Adds `cursor: grab` to `#token-action-hud` to restore the drag affordance for the Always Draggable setting

## Test plan

- [ ] Select an investigator token — confirm HUD shows **[Actions] [Tags] [Utility]** left-to-right in a single row
- [ ] Hover each tab — confirm its dropdown expands downward with the correct groups
- [ ] With "Always Draggable" enabled in TAH Core settings, confirm the HUD can be dragged to a new screen position

🤖 Generated with [Claude Code](https://claude.com/claude-code)